### PR TITLE
Call `node keystone.js` when starting the app

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
     "npm": "1.2.x"
   },
   "scripts": {
-    "start": "keystone.js"
+    "start": "node keystone.js"
   }
 }


### PR DESCRIPTION
When git-cloning the keystone-demo project, `keystone.js` isn't actually executable, and a `npm start` will fail.
